### PR TITLE
사이드바 트리 조회 API 구현 (defaultFolder 제외)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,15 @@ import { UserModule } from './user/user.module';
 import { AuthService } from './auth/auth.service';
 import { Auth } from './auth/auth.entity';
 import { CommonModule } from './common.module';
+import { SidebarController } from './sidebar/sidebar.controller';
+import { Workspace } from './workspace/workspace.entity';
+import { WorkspaceService } from './workspace/workspace.service';
+import { UserWorkspace } from './workspace/user-workspace.entity';
+import { SidebarService } from './sidebar/sidebar.service';
+import { FolderService } from './folder/folder.service';
+import { Folder } from './folder/folder.entity';
+import { ChecklistService } from './checklist/checklist.service';
+import { Checklist } from './checklist/checklist.entity';
 
 @Module({
   imports: [
@@ -28,11 +37,25 @@ import { CommonModule } from './common.module';
     }),
     AuthModule,
     UserModule,
-    TypeOrmModule.forFeature([Auth]),
+    TypeOrmModule.forFeature([
+      Auth,
+      Workspace,
+      UserWorkspace,
+      Folder,
+      Checklist,
+    ]),
     JwtModule.register({}),
     CommonModule,
   ],
-  controllers: [AppController, AuthController],
-  providers: [AppService, UserService, AuthService],
+  controllers: [AppController, AuthController, SidebarController],
+  providers: [
+    AppService,
+    UserService,
+    AuthService,
+    WorkspaceService,
+    SidebarService,
+    FolderService,
+    ChecklistService,
+  ],
 })
 export class AppModule {}

--- a/src/checklist/checklist.service.ts
+++ b/src/checklist/checklist.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Checklist } from './checklist.entity';
+import { FolderService } from '../folder/folder.service';
+
+@Injectable()
+export class ChecklistService {
+  constructor(
+    @InjectRepository(Checklist)
+    private readonly checklistRepository: Repository<Checklist>,
+    private readonly folderService: FolderService,
+  ) {}
+
+  async findByFolderId(folderId: number) {
+    const folder = await this.folderService.findById(folderId);
+    return this.checklistRepository.find({
+      where: { folder },
+    });
+  }
+}

--- a/src/folder/folder.service.ts
+++ b/src/folder/folder.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Folder } from './folder.entity';
+import { WorkspaceService } from '../workspace/workspace.service';
+
+@Injectable()
+export class FolderService {
+  constructor(
+    @InjectRepository(Folder)
+    private readonly folderRepository: Repository<Folder>,
+    private readonly workspaceService: WorkspaceService,
+  ) {}
+
+  async findById(folderId: number) {
+    return this.folderRepository.findOne({
+      where: { id: folderId },
+      select: ['id', 'name'],
+    });
+  }
+
+  async findByWorkspaceId(workspaceId: number) {
+    const workspace = await this.workspaceService.findById(workspaceId);
+    return this.folderRepository.find({
+      where: { workspace },
+    });
+  }
+}

--- a/src/sidebar/sidebar.controller.ts
+++ b/src/sidebar/sidebar.controller.ts
@@ -1,0 +1,66 @@
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { AuthGuard } from '@nestjs/passport';
+import { SidebarService } from './sidebar.service';
+
+@ApiTags('사이드바')
+@Controller('/sidebar')
+export class SidebarController {
+  constructor(private readonly sidebarService: SidebarService) {}
+
+  @Get('/tree')
+  @UseGuards(AuthGuard('jwt'))
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    summary: '사이드바 트리 조회',
+    description: '사이드바 트리 조회',
+  })
+  @ApiOkResponse({
+    description: '사용자의 체크리스트를 사이드바 트리구조로 조회한다.',
+    schema: {
+      example: {
+        workspace: [
+          {
+            id: 0,
+            name: 'string',
+            defaultFolder: [
+              {
+                id: 0,
+                title: 'string',
+              },
+              {
+                id: 0,
+                title: 'string',
+              },
+            ],
+            folder: [
+              {
+                id: 0,
+                name: 'string',
+                checklist: [
+                  {
+                    id: 0,
+                    title: 'string',
+                  },
+                  {
+                    id: 0,
+                    title: 'string',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  })
+  async getCheckListTree(@Req() req) {
+    const userId = req.user.id;
+    return this.sidebarService.findSidebarTree(userId);
+  }
+}

--- a/src/sidebar/sidebar.service.ts
+++ b/src/sidebar/sidebar.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { WorkspaceService } from '../workspace/workspace.service';
+import { UserWorkspace } from '../workspace/user-workspace.entity';
+import { FolderService } from '../folder/folder.service';
+import { ChecklistService } from '../checklist/checklist.service';
+
+@Injectable()
+export class SidebarService {
+  constructor(
+    private readonly workspaceService: WorkspaceService,
+    private readonly folderService: FolderService,
+    private readonly checklistService: ChecklistService,
+  ) {}
+
+  async findSidebarTree(userId: number) {
+    const workspaces = await this.findWorkspaces(userId);
+    return { workspace: workspaces };
+  }
+
+  async findWorkspaces(userId: number) {
+    const userWorkspaces = await this.workspaceService.findByUserId(userId);
+    const folders = userWorkspaces.map(async (item: UserWorkspace) => ({
+      id: item.workspace.id,
+      name: item.workspace.name,
+      defaultFolder: [
+        { id: 1, title: '임시1' },
+        { id: 2, title: '임시2' },
+      ],
+      folder: await Promise.all(
+        item.workspace.folder_order.map(async (folderId) =>
+          this.findFolder(folderId),
+        ),
+      ),
+    }));
+    return Promise.all(folders);
+  }
+
+  async findFolder(folderId: number) {
+    const folder = await this.folderService.findById(folderId);
+    return {
+      id: folder.id,
+      name: folder.name,
+      checklist: await this.findCheckLists(folder.id),
+    };
+  }
+
+  async findCheckLists(folderId: number) {
+    const checklists = await this.checklistService.findByFolderId(folderId);
+    return checklists.map((checklist) => ({
+      id: checklist.id,
+      title: checklist.title,
+    }));
+  }
+}

--- a/src/workspace/user-workspace.entity.ts
+++ b/src/workspace/user-workspace.entity.ts
@@ -18,6 +18,7 @@ export class UserWorkspace {
   user: User;
 
   @ManyToOne(() => Workspace)
+  @JoinColumn({ name: 'workspace_id' })
   workspace: Workspace;
 
   @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })

--- a/src/workspace/workspace.service.ts
+++ b/src/workspace/workspace.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UserWorkspace } from './user-workspace.entity';
+import { UserService } from '../user/user.service';
+import { Workspace } from './workspace.entity';
+
+@Injectable()
+export class WorkspaceService {
+  constructor(
+    @InjectRepository(Workspace)
+    private readonly workspaceRepository: Repository<Workspace>,
+    @InjectRepository(UserWorkspace)
+    private readonly userWorkspaceRepository: Repository<UserWorkspace>,
+    private readonly userService: UserService,
+  ) {}
+
+  async findById(workspaceId: number) {
+    return this.workspaceRepository.findOne({
+      where: { id: workspaceId },
+      select: ['name', 'folder_order'],
+    });
+  }
+
+  async findByUserId(userId: number) {
+    const user = await this.userService.findOneUser(userId);
+    return this.userWorkspaceRepository.find({
+      where: { user },
+      relations: ['workspace'],
+    });
+  }
+}


### PR DESCRIPTION
사이드바 트리 조회 API
- defaultFolder는 기획적으로 명확하지 않은 부분이 있어 임시 데이터 내려가도록 구현
- 사용자 생성할 때 자동으로 기본 워크스페이스와 기본 폴더 생성해주는 기능 추가 후, defaultFolder 추가 구현 예정

의문점??
- 기본 워크스페이스는 삭제 불가한 것인지?
- 각 워크스페이스를 생성할 때마다 defaultFolder를 하나씩 갖는 것인지?
- defaultFolder는 뭘로 구분할지?
   - 각 워크스페이스별로 default_folder_id 컬럼 추가? 
- 워크스페이스도 defaultWorkspace 여부를 관리할 필요가 있을지?